### PR TITLE
Add client and server test structure

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["es2015", "react"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+# Other
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "test": "npm run test:server && npm run test:client",
     "test:server": "mocha test/server/.setup.js test/server/**.spec.js test/server/*/*.spec.js",
     "test:server:watch": "mocha test/server/.setup.js test/server/**.spec.js test/server/*/*.spec.js --watch",
-    "test:client": "echo TODO: ADD CLIENT TESTS",
-    "test:client:watch": "echo TODO: ADD CLIENT WATCH TESTS"
+    "test:client": "mocha test/client/.setup.js test/client/**.spec.js test/client/*/*.spec.js",
+    "test:client:watch": "mocha test/client/.setup.js test/client/**.spec.js test/client/*/*.spec.js --watch"
   },
   "repository": {
     "type": "git",
@@ -26,8 +26,19 @@
   },
   "homepage": "https://github.com/Misguided-Butterflies/TwitchLite#readme",
   "devDependencies": {
+    "babel-register": "^6.18.0",
     "chai": "^3.5.0",
+    "chai-enzyme": "^0.6.0",
+    "enzyme": "^2.5.1",
+    "jsdom": "^9.8.3",
     "mocha": "^3.1.2",
     "sinon": "^1.17.6"
+  },
+  "dependencies": {
+    "babel-core": "^6.18.2",
+    "babel-preset-es2015": "^6.18.0",
+    "babel-preset-react": "^6.16.0",
+    "react": "^15.3.2",
+    "react-dom": "^15.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "twitchlite",
+  "version": "1.0.0",
+  "description": "Automated stream highlighting feed for Twitch users",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Misguided-Butterflies/TwitchLite.git"
+  },
+  "keywords": [
+    "twitch",
+    "bot",
+    "irc"
+  ],
+  "author": "Sam Sherman, Shensen Wang, John Oksasoglu",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/Misguided-Butterflies/TwitchLite/issues"
+  },
+  "homepage": "https://github.com/Misguided-Butterflies/TwitchLite#readme"
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,11 @@
   "description": "Automated stream highlighting feed for Twitch users",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "npm run test:server && npm run test:client",
+    "test:server": "mocha test/server/.setup.js test/server/**.spec.js test/server/*/*.spec.js",
+    "test:server:watch": "mocha test/server/.setup.js test/server/**.spec.js test/server/*/*.spec.js --watch",
+    "test:client": "echo TODO: ADD CLIENT TESTS",
+    "test:client:watch": "echo TODO: ADD CLIENT WATCH TESTS"
   },
   "repository": {
     "type": "git",
@@ -20,5 +24,10 @@
   "bugs": {
     "url": "https://github.com/Misguided-Butterflies/TwitchLite/issues"
   },
-  "homepage": "https://github.com/Misguided-Butterflies/TwitchLite#readme"
+  "homepage": "https://github.com/Misguided-Butterflies/TwitchLite#readme",
+  "devDependencies": {
+    "chai": "^3.5.0",
+    "mocha": "^3.1.2",
+    "sinon": "^1.17.6"
+  }
 }

--- a/test/client/.setup.js
+++ b/test/client/.setup.js
@@ -1,0 +1,40 @@
+// See example here:
+// https://github.com/lelandrichardson/enzyme-example-karma-webpack/blob/master/test/.setup.js
+require('babel-register')();
+
+var jsdom = require('jsdom').jsdom;
+var exposed = ['window', 'navigator', 'document'];
+
+global.document = jsdom('');
+global.window = document.defaultView;
+Object.keys(document.defaultView).forEach(property => {
+  if (typeof global[property] === 'undefined') {
+    exposed.push(property);
+    global[property] = document.defaultView[property];
+  }
+});
+
+global.navigator = {
+  userAgent: 'node.js'
+};
+
+documentRef = document;
+
+// As per the test script inside package.json, this file will be run
+// before running all client tests. Thus, common imports can be done
+// once here, rather than each time in every test file
+var React = require('react');
+var chai = require('chai');
+var sinon = require('sinon');
+var enzyme = require('enzyme');
+var chaiEnzyme = require('chai-enzyme');
+
+chai.use(chaiEnzyme());
+
+global.React = React;
+global.chai = chai;
+global.expect = chai.expect;
+global.spy = sinon.spy;
+global.mount = enzyme.mount;
+global.shallow = enzyme.shallow;
+global.render = enzyme.render;

--- a/test/client/index.spec.js
+++ b/test/client/index.spec.js
@@ -1,0 +1,13 @@
+let component = (
+  <div>
+    <h1>Test Component</h1>
+  </div>
+);
+
+describe('client tests', () => {
+  it('should render something', () => {
+    let wrapper = shallow(component);
+
+    expect(wrapper.contains(<h1>Test Component</h1>)).to.equal(true);
+  });
+});

--- a/test/server/.setup.js
+++ b/test/server/.setup.js
@@ -1,0 +1,5 @@
+// As per the test script inside package.json, this file will be run
+// before running all server tests. Thus, common imports can be done
+// once here, rather than each time in every test file
+global.chai = require('chai');
+global.expect = chai.expect;

--- a/test/server/index.spec.js
+++ b/test/server/index.spec.js
@@ -1,0 +1,5 @@
+describe('server', function() {
+  it('should pass a test', function() {
+    expect(true).to.be.true;
+  });
+});


### PR DESCRIPTION
This installs necessary packages for and adds sample tests for both client and server. Server tests are running with mocha and chai, while client testing is setup with Enzyme for React component testing. Test files in both client and server are named `**.spec.js`. So if we have a component somewhere called `TopBar.js`, the corresponding test for that component would be called `TopBar.spec.js` and placed in the appropriate test folder.