### PR TITLE
Add eslint config to project

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,14 @@
+{
+  "parser": "babel-eslint",
+  "extends": [
+    "./node_modules/eslint-config-hackreactor/index.js",
+    "plugin:react/recommended"
+  ],
+  "ecmaVersion": 6,
+  "plugins": [
+    "react"
+  ],
+  "rules": {
+    "react/react-in-jsx-scope": 0
+  }
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test:server": "mocha test/server/.setup.js test/server/**.spec.js test/server/*/*.spec.js",
     "test:server:watch": "mocha test/server/.setup.js test/server/**.spec.js test/server/*/*.spec.js --watch",
     "test:client": "mocha test/client/.setup.js test/client/**.spec.js test/client/*/*.spec.js",
-    "test:client:watch": "mocha test/client/.setup.js test/client/**.spec.js test/client/*/*.spec.js --watch"
+    "test:client:watch": "mocha test/client/.setup.js test/client/**.spec.js test/client/*/*.spec.js --watch",
+    "lint": "eslint ./"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -26,10 +26,14 @@
   },
   "homepage": "https://github.com/Misguided-Butterflies/TwitchLite#readme",
   "devDependencies": {
+    "babel-eslint": "^7.1.0",
     "babel-register": "^6.18.0",
     "chai": "^3.5.0",
     "chai-enzyme": "^0.6.0",
     "enzyme": "^2.5.1",
+    "eslint": "^3.9.1",
+    "eslint-config-hackreactor": "git://github.com/reactorcore/eslint-config-hackreactor",
+    "eslint-plugin-react": "^6.6.0",
     "jsdom": "^9.8.3",
     "mocha": "^3.1.2",
     "sinon": "^1.17.6"


### PR DESCRIPTION
This adds a `.eslintrc` config file to our project, and installs the necessary packages to enable linting of our React code. If your editor is not configured to run eslint based on a project's `.eslintrc` file, then you can alternatively run `npm run lint` and get the linting output in the command line.