### PR TITLE
Alter db cleaning inside server + db tests

### DIFF
--- a/test/db/highlight.spec.js
+++ b/test/db/highlight.spec.js
@@ -20,7 +20,7 @@ describe('Highlights Model', function() {
 
   beforeEach(function(done) {
     var clearDB = function() {
-      Highlight.remove({}).exec();
+      Highlight.remove(obj).exec();
       return done();
     };
 
@@ -51,7 +51,7 @@ describe('Highlights Model', function() {
   it('should only add one highlight at once', function(done) {
     insertOne(obj)
     .then( () => {
-      return findAll();
+      return findAll(obj);
     })
     .then(res => {
       expect(res.length).to.equal(1);

--- a/test/server/server.spec.js
+++ b/test/server/server.spec.js
@@ -29,7 +29,10 @@ var fakeHighlight2 = {
 describe('server', () => {
 
   beforeEach(done => {
-    highlights.remove({})
+    highlights.remove(fakeHighlight)
+    .then(() => {
+      return highlights.remove(fakeHighlight2);
+    })
     .then(() => {
       done();
     });
@@ -101,7 +104,9 @@ describe('server', () => {
       request(app)
         .get('/highlights')
         .expect(res => {
-          expect(res.body).to.have.length(2);
+          // Use >= 2 to not make assumptions about how many real entries
+          // were in our db before this test
+          expect(res.body.length >= 2).to.equal(true);
         })
         .end(err => err ? done(err) : done());
     });


### PR DESCRIPTION
Formerly, portions of our test suite would remove _all_ entries from the database, rather than just the sample ones it inserted, meaning that all of our real data would get cleaned out locally every time we ran the tests. Now the tests instead only remove the sample data that they insert.

Closes #108 