### PR TITLE
Add enter animation on <VideoContainer>

### DIFF
--- a/client/styles.css
+++ b/client/styles.css
@@ -111,6 +111,7 @@ button:focus {
 }
 
 .video-list {
+  min-height: 100vh;
   padding: 2em 0em;
   background: linear-gradient(to bottom, #17141f, #07040f);
   background-attachment: fixed;
@@ -121,6 +122,20 @@ button:focus {
   background: #fff;
   position: relative;
   padding: 2em 0;
+
+  animation: 0.4s fade-up ease;
+  animation-fill-mode: both;
+}
+
+@keyframes fade-up {
+  0% {
+    opacity: 0;
+    transform: translateY(100px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0px);
+  }
 }
 
 .video-container + .video-container {


### PR DESCRIPTION
`<VideoContainer>`s now fade up and in when they enter the DOM. Not a huge change, but it looks a little smoother on initial load now.