### PR TITLE
Trigger rendering more highlights earlier

### DIFF
--- a/client/src/index.js
+++ b/client/src/index.js
@@ -79,13 +79,17 @@ class App extends React.Component {
     let $html = document.documentElement;
     let scrollDistanceFromTop = window.pageYOffset;
 
+    // Distance from bottom we want to start loading new highlights
+    // Makes for a smoother infinite scroll
+    const additionalScrollPadding = 500;
+
     // Document height calculation can vary by browser, so calculate all
     // possibilities and take the highest one
     let docHeight = Math.max($body.scrollHeight, $body.offsetHeight,
       $html.clientHeight, $html.scrollHeight, $html.offsetHeight);
     let windowHeight = window.innerHeight;
 
-    if (scrollDistanceFromTop === docHeight - windowHeight) {
+    if (scrollDistanceFromTop === docHeight - windowHeight - additionalScrollPadding) {
       this.increaseList();
     }
   }

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -81,7 +81,7 @@ class App extends React.Component {
 
     // Distance from bottom we want to start loading new highlights
     // Makes for a smoother infinite scroll
-    const additionalScrollPadding = 500;
+    const additionalScrollPadding = 800;
 
     // Document height calculation can vary by browser, so calculate all
     // possibilities and take the highest one
@@ -89,7 +89,7 @@ class App extends React.Component {
       $html.clientHeight, $html.scrollHeight, $html.offsetHeight);
     let windowHeight = window.innerHeight;
 
-    if (scrollDistanceFromTop === docHeight - windowHeight - additionalScrollPadding) {
+    if (scrollDistanceFromTop >= docHeight - windowHeight - additionalScrollPadding) {
       this.increaseList();
     }
   }

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -75,15 +75,17 @@ class App extends React.Component {
   }
 
   checkScrollBottom() {
-    var $body = document.body;
-    var $html = document.documentElement;
+    let $body = document.body;
+    let $html = document.documentElement;
+    let scrollDistanceFromTop = window.pageYOffset;
 
-    var scrollTop = window.pageYOffset;
-    var docHeight = Math.max($body.scrollHeight, $body.offsetHeight,
+    // Document height calculation can vary by browser, so calculate all
+    // possibilities and take the highest one
+    let docHeight = Math.max($body.scrollHeight, $body.offsetHeight,
       $html.clientHeight, $html.scrollHeight, $html.offsetHeight);
-    var windowHeight = window.innerHeight;
+    let windowHeight = window.innerHeight;
 
-    if (scrollTop === docHeight - windowHeight) {
+    if (scrollDistanceFromTop === docHeight - windowHeight) {
       this.increaseList();
     }
   }


### PR DESCRIPTION
Formerly new highlights were rendered only when the user had reached the very bottom of the page, but with these changes, it now triggers 800px sooner, so the infinite scroll is much smoother when casually scrolling.