### PR TITLE
Make new highlights render earlier

### DIFF
--- a/client/src/index.js
+++ b/client/src/index.js
@@ -75,15 +75,21 @@ class App extends React.Component {
   }
 
   checkScrollBottom() {
-    var $body = document.body;
-    var $html = document.documentElement;
+    let $body = document.body;
+    let $html = document.documentElement;
+    let scrollDistanceFromTop = window.pageYOffset;
 
-    var scrollTop = window.pageYOffset;
-    var docHeight = Math.max($body.scrollHeight, $body.offsetHeight,
+    // Distance from bottom we want to start loading new highlights
+    // Makes for a smoother infinite scroll
+    const additionalScrollPadding = 800;
+
+    // Document height calculation can vary by browser, so calculate all
+    // possibilities and take the highest one
+    let docHeight = Math.max($body.scrollHeight, $body.offsetHeight,
       $html.clientHeight, $html.scrollHeight, $html.offsetHeight);
-    var windowHeight = window.innerHeight;
+    let windowHeight = window.innerHeight;
 
-    if (scrollTop === docHeight - windowHeight) {
+    if (scrollDistanceFromTop >= docHeight - windowHeight - additionalScrollPadding) {
       this.increaseList();
     }
   }


### PR DESCRIPTION
Formerly new highlights were rendered only when the user had reached the very bottom of the page, but with these changes, it now triggers 800px sooner, so the infinite scroll is smoother when casually scrolling.