### PR TITLE
Add minification and update package.json build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:db": "mocha test/db/.setup.js test/db/**.spec.js",
     "test:db:watch": "mocha test/db/.setup.js test/db/**.spec.js --watch",
     "lint": "eslint ./",
-    "build": "webpack",
+    "build": "webpack --prod",
     "build:watch": "webpack -w",
     "postinstall": "npm run build",
     "start": "npm run start:workers & npm run start:server",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,11 +4,18 @@ var path = require('path');
 var BUILD_DIR = path.resolve(__dirname, 'client');
 var APP_DIR = path.resolve(__dirname, 'client/src');
 
-var definePlugin = new webpack.DefinePlugin({
+var isProduction = process.argv.indexOf('--prod') !== -1;
+var plugins = [];
+
+plugins.push(new webpack.DefinePlugin({
   'process.env': {
     'TWITCH_CLIENT_ID': JSON.stringify(process.env.TWITCH_CLIENT_ID)
   }
-});
+}));
+
+if (isProduction) {
+  plugins.push(new webpack.optimize.UglifyJsPlugin());
+}
 
 var config = {
   entry: APP_DIR + '/index.js',
@@ -16,7 +23,7 @@ var config = {
     path: BUILD_DIR,
     filename: 'bundle.js'
   },
-  plugins: [definePlugin],
+  plugins: plugins,
   module: {
     loaders: [
       {


### PR DESCRIPTION
The `build` script inside `package.json` (the one that's run from the `postinstall` script) now triggers minification of our code, so deployments will have minified code. The `build:watch` command still builds without minification though.