### PR TITLE
Add default language filter on Twitch API calls

### DIFF
--- a/test/workers/workerMaster.spec.js
+++ b/test/workers/workerMaster.spec.js
@@ -49,6 +49,32 @@ describe('workerMaster', function() {
 
       expect(result).to.be.an.instanceOf(Promise);
     });
+
+    it('should get only English language streams by default', function(done) {
+      var options = { quantity: 10 };
+      workerMaster.getStreams(options)
+      .then(streams => {
+        streams.forEach(stream => {
+          expect(stream.channel.language).to.equal('en');
+        });
+      })
+      .then( () => {
+        done();
+      });
+    });
+
+    it('should be able to get streams in other languages', function(done) {
+      var language = 'ko';
+      workerMaster.getStreams({ quantity: 10, language })
+      .then(streams => {
+        streams.forEach(stream => {
+          expect(stream.channel.language).to.equal(language);
+        });
+      })
+      .then( () => {
+        done();
+      });
+    });
   });
 
   describe('getTopStreams', function() {

--- a/workers/workerMaster.js
+++ b/workers/workerMaster.js
@@ -14,8 +14,12 @@ var activeWorkers = {};
 
 var workerMaster = {
   // Fetch a single chunk of streams
-  getStreams: function(quantity, offset) {
-    return fetch(`https://api.twitch.tv/kraken/streams?limit=${quantity}&offset=${offset}`, fetchOptions)
+  // The default to {} is just a safeguard against a type error in case the
+  // function is called with no arguments at all; see here:
+  // http://stackoverflow.com/questions/37453235/typeerror-cannot-match-against-undefined-or-null
+  // The destructuring + default params still otherwise work perfectly as intended
+  getStreams: function({ quantity = 10, offset = 0, language = 'en'} = {}) {
+    return fetch(`https://api.twitch.tv/kraken/streams?language=${language}&limit=${quantity}&offset=${offset}`, fetchOptions)
       .then(response => {
         return response.json();
       })
@@ -32,7 +36,10 @@ var workerMaster = {
     var chunkCount = Math.ceil(quantity / 50);
 
     for (var i = 0; i < chunkCount; i++) {
-      streamPromises.push(this.getStreams(50, 50 * i));
+      streamPromises.push(this.getStreams({
+        quantity: 50,
+        offset: 50 * i
+      }));
     }
 
     return Promise.all(streamPromises)
@@ -103,16 +110,17 @@ var workerMaster = {
         throw new Error(`Channel ${channelName} does not store VODs`);
         return;
       }
-      var streamStart = new Date(data.videos[0]['recorded_at']);
+      var vod = data.videos[0];
+      var streamStart = new Date(vod['recorded_at']);
       streamStart = streamStart.getTime();
 
       return {
-        status: data.videos[0].status,
-        vodId: data.videos[0]._id,
-        link: data.videos[0].url,
-        game: data.videos[0].game,
-        streamTitle: data.videos[0].title,
-        preview: data.videos[0].preview,
+        status: vod.status,
+        vodId: vod._id,
+        link: vod.url,
+        game: vod.game,
+        streamTitle: vod.title,
+        preview: vod.preview,
         streamStart
       };
     });


### PR DESCRIPTION
Previously we were fetching all international streams, but I've added a default to English language streams, though I have also made the API flexible so that we could easily make calls to the Twitch API later for other languages. Tests for the English default, and the ability to get other language streams (tested with Korean), are also present.