### PR TITLE
Fix focus styles for nav buttons

### DIFF
--- a/client/styles.css
+++ b/client/styles.css
@@ -279,7 +279,8 @@ button:focus {
 }
 
 .nav-button,
-.nav-button:active {
+.nav-button:active,
+.nav-button:focus {
   color: #fff !important;
   text-transform: uppercase;
   background: transparent;


### PR DESCRIPTION
Formerly, nav buttons with focus would change size because of a padding property inherited from regular focused buttons, but this fixes that.